### PR TITLE
doc: update Jaka Hudoklin's website

### DIFF
--- a/doc/index.rst
+++ b/doc/index.rst
@@ -103,5 +103,5 @@ The project was originally written by `Jaka Hudoklin`_,
 and then `forked <https://github.com/offlinehacker/sphinxcontrib.jinjadomain>`__ and maintained
 by `Yaal Coop`_ and distributed under BSD license.
 
-.. _Jaka Hudoklin: http://www.offlinehacker.net/
+.. _Jaka Hudoklin: https://jakahudoklin.com
 .. _Yaal Coop: https://yaal.coop


### PR DESCRIPTION
The previous website dos not work anymore and the domain has expired. Jaka Hudoklin's [github account](https://github.com/offlinehacker) shows jakahudoklin.com as his new website.