### PR TITLE
Add a [source] link to the documented templates

### DIFF
--- a/doc/index.rst
+++ b/doc/index.rst
@@ -21,25 +21,25 @@ jinja templates.
 
 .. sourcecode:: rst
 
-   .. jinja:template:: /etc/network/interfaces
+   .. jinja:template:: emails/welcome.html
 
-      Template for network config
+      Welcome email, sent after a registration
 
-      :param hostname: your computer's hostname
-      :type hostname: str
-      :param ip: your computer's ip
-      :type ip: str
+      :param user: the user to greet
+      :type user: User
+      :param login_url: where the user can log in
+      :type login_url: str
 
 will be rendered as:
 
-.. jinja:template:: /etc/network/interfaces
+.. jinja:template:: emails/welcome.html
 
-  Template for network config
+  Welcome email, sent after a registration
 
-  :param hostname: your computer's hostname
-  :type hostname: str
-  :param ip: your computer's ip
-  :type ip: str
+  :param user: the user to greet
+  :type user: User
+  :param login_url: where the user can log in
+  :type login_url: str
 
 .. _directives:
 
@@ -96,6 +96,24 @@ Documents are rebuilt when the templates they document are edited.
    full rebuild. Note that templates being *added to* or *removed from* a
    documented directory still go unnoticed, as Sphinx dependencies can only be
    files. Such changes need a full rebuild, with ``sphinx-build --fresh-env``.
+
+Template sources
+----------------
+
+Documented templates get a ``[source]`` link, pointing at a page that displays
+their highlighted source, the way :mod:`sphinx.ext.viewcode` does for python
+modules. Only templates living inside ``jinja_template_path`` get such a page.
+
+Templates are highlighted with the ``html+jinja`` Pygments lexer, which fits
+HTML templates. If your templates are written in another language, set
+``jinja_template_lexer`` to another `Pygments lexer
+<https://pygments.org/languages/>`__:
+
+.. sourcecode:: python
+
+   jinja_template_lexer = "jinja"
+
+.. versionadded:: 0.2
 
 Directives
 ----------

--- a/jinja_autodoc/__init__.py
+++ b/jinja_autodoc/__init__.py
@@ -7,6 +7,9 @@ from sphinx.util.typing import ExtensionMetadata
 
 from .autotemplate import AutojinjaDirective
 from .domain import JinjaDomain
+from .viewsource import collect_pages
+from .viewsource import doctree_read
+from .viewsource import doctree_resolved
 
 
 def resolve_template_path(app: Sphinx, config: Config) -> None:
@@ -25,7 +28,11 @@ def setup(app: Sphinx) -> ExtensionMetadata:
     app.add_directive("autotemplate", AutojinjaDirective)
     app.add_config_value("jinja_template_path", "", "env")
     app.add_config_value("jinja_template_pattern", "", "env")
+    app.add_config_value("jinja_template_lexer", "html+jinja", "")
     app.connect("config-inited", resolve_template_path)
+    app.connect("doctree-read", doctree_read)
+    app.connect("doctree-resolved", doctree_resolved)
+    app.connect("html-collect-pages", collect_pages)
 
     return {
         "version": importlib.metadata.version("jinja-autodoc"),

--- a/jinja_autodoc/domain.py
+++ b/jinja_autodoc/domain.py
@@ -47,7 +47,7 @@ class JinjaResource(ObjectDescription):
 
     def add_target_and_index(self, name_cls, sig, signode):
         signode["ids"].append(jinja_resource_anchor(*name_cls[1:]))
-        self.env.domaindata["jinja"][self.method][sig] = (self.env.docname, "")
+        self.env.domaindata["jinja"][self.method][sig] = (self.env.docname, "", None)
 
 
 class JinjaIndex(Index):
@@ -92,7 +92,7 @@ class JinjaDomain(Domain):
 
     object_types = {"template": ObjType("template", "template")}
     directives = {"template": JinjaResource}
-    initial_data = {"template": {}}  # path: (docname, synopsis)
+    initial_data = {"template": {}}  # path: (docname, synopsis, source)
     indices = [JinjaIndex]
 
     @property

--- a/jinja_autodoc/viewsource.py
+++ b/jinja_autodoc/viewsource.py
@@ -1,0 +1,150 @@
+"""Source pages for the documented jinja templates.
+
+Each documented template gets a page displaying its highlighted source, and a
+``[source]`` link in its documentation, the way :mod:`sphinx.ext.viewcode` does
+for python modules.
+"""
+
+import html
+import os
+import posixpath
+from collections.abc import Iterator
+from typing import TYPE_CHECKING
+from typing import Any
+from typing import cast
+
+from docutils import nodes
+from sphinx import addnodes
+from sphinx.application import Sphinx
+from sphinx.builders import Builder
+from sphinx.locale import _
+from sphinx.locale import __
+from sphinx.util.display import status_iterator
+from sphinx.util.nodes import make_refnode
+
+from .domain import jinja_resource_anchor
+
+if TYPE_CHECKING:
+    from sphinx.builders.html import StandaloneHTMLBuilder
+
+OUTPUT_DIRNAME = "_jinja"
+
+
+class jinja_source_anchor(nodes.Element):
+    """Placeholder for a ``[source]`` link, resolved once the builder is known."""
+
+
+def is_supported_builder(builder: Builder) -> bool:
+    """Tell whether a builder can link to the generated source pages.
+
+    ``singlehtml`` cannot link to a page that is not part of its single
+    document, and ``epub`` does not list such pages in its manifest.
+    """
+    return (
+        builder.format == "html"
+        and builder.name != "singlehtml"
+        and not builder.name.startswith("epub")
+    )
+
+
+def source_page_name(sig: str) -> str:
+    """Return the name of the page displaying the source of a template."""
+    return posixpath.join(OUTPUT_DIRNAME, *sig.split(os.sep))
+
+
+def template_source_path(root: str, sig: str) -> str | None:
+    """Locate the template file documented under the *sig* signature.
+
+    Signatures escaping the template root, by being absolute or by walking the
+    tree up, are ignored: source pages get published, and must not expose
+    arbitrary files of the machine that built the documentation.
+    """
+    if not root:
+        return None
+
+    path = os.path.normpath(os.path.join(root, sig))
+    if not path.startswith(os.path.join(root, "")):
+        return None
+
+    return path if os.path.isfile(path) else None
+
+
+def doctree_read(app: Sphinx, doctree: nodes.Node) -> None:
+    """Remember where the documented templates come from, and mark their signature."""
+    templates = app.env.domaindata["jinja"]["template"]
+    for objnode in doctree.findall(addnodes.desc):
+        if objnode.get("domain") != "jinja":
+            continue
+
+        for signode in objnode.findall(addnodes.desc_signature):
+            sig = signode.get("path")
+            # Signatures excluded from the index have no domain data entry.
+            if sig not in templates:
+                continue
+
+            source = template_source_path(app.config.jinja_template_path, sig)
+            if source is None:
+                continue
+
+            docname, synopsis, _previous = templates[sig]
+            templates[sig] = (docname, synopsis, source)
+            app.env.note_dependency(source)
+            signode += jinja_source_anchor()
+
+
+def doctree_resolved(app: Sphinx, doctree: nodes.Node, docname: str) -> None:
+    """Turn the marked signatures into links, or drop them for other builders."""
+    supported = is_supported_builder(app.builder)
+    for node in list(doctree.findall(jinja_source_anchor)):
+        if not supported:
+            node.parent.remove(node)
+            continue
+
+        sig = node.parent["path"]
+        anchor = nodes.inline("", _("[source]"), classes=["viewcode-link"])
+        node.replace_self(
+            make_refnode(app.builder, docname, source_page_name(sig), None, anchor)
+        )
+
+
+def collect_pages(app: Sphinx) -> Iterator[tuple[str, dict[str, Any], str]]:
+    """Generate a page displaying the source of each documented template."""
+    if not is_supported_builder(app.builder):
+        return
+
+    templates = app.env.domaindata["jinja"]["template"]
+    documented = sorted(item for item in templates.items() if item[1][2])
+    # Only HTML builders reach this point, and they carry a highlighter.
+    highlighter = cast("StandaloneHTMLBuilder", app.builder).highlighter
+    lexer = app.config.jinja_template_lexer
+
+    for sig, (docname, _synopsis, source) in status_iterator(
+        documented,
+        __("highlighting jinja templates... "),
+        "blue",
+        len(documented),
+        app.verbosity,
+        lambda item: item[0],
+    ):
+        with open(source, encoding="utf-8") as fd:
+            code = fd.read()
+
+        # The lexer is configured once for every template, so a template it does
+        # not fit should not warn about it: highlight in relaxed mode instead.
+        highlighted = highlighter.highlight_block(code, lexer, force=True)
+        pagename = source_page_name(sig)
+        backlink = (
+            app.builder.get_relative_uri(pagename, docname)
+            + "#"
+            + jinja_resource_anchor("template", sig)
+        )
+        context = {
+            "parents": [],
+            "title": sig,
+            "body": (
+                f"<h1>{html.escape(sig)}</h1>"
+                f'<a class="viewcode-back" href="{backlink}">{_("[docs]")}</a>'
+                f"{highlighted}"
+            ),
+        }
+        yield pagename, context, "page.html"

--- a/tests/roots/test-viewsource/conf.py
+++ b/tests/roots/test-viewsource/conf.py
@@ -1,0 +1,3 @@
+project = "test-viewsource"
+extensions = ["jinja_autodoc"]
+jinja_template_path = "templates"

--- a/tests/roots/test-viewsource/index.rst
+++ b/tests/roots/test-viewsource/index.rst
@@ -1,0 +1,14 @@
+.. autotemplate:: greeting.html
+
+.. jinja:template:: other.html
+   :no-index:
+
+   Documented without an index entry.
+
+.. jinja:template:: ../conf.py
+
+   Outside of the template root.
+
+.. py:function:: unrelated_domain_object()
+
+   Objects of other domains are left alone.

--- a/tests/roots/test-viewsource/templates/greeting.html
+++ b/tests/roots/test-viewsource/templates/greeting.html
@@ -1,0 +1,7 @@
+{#
+Greets the user
+
+:param name: the name to greet
+:type name: str
+#}
+<p>Hello {{ name }}!</p>

--- a/tests/roots/test-viewsource/templates/other.html
+++ b/tests/roots/test-viewsource/templates/other.html
@@ -1,0 +1,1 @@
+<p>Another template.</p>

--- a/tests/test_autotemplate_directive/test_file_filter.html
+++ b/tests/test_autotemplate_directive/test_file_filter.html
@@ -10,6 +10,13 @@
         templatedir/template1.in
       </span>
     </span>
+    <a class="reference internal" href="_jinja/templatedir/template1.in.html">
+      <span class="viewcode-link">
+        <span class="pre">
+          [source]
+        </span>
+      </span>
+    </a>
     <a class="headerlink" href="#template-templatedir-template1.in" title="Link to this definition">
       ¶
     </a>

--- a/tests/test_autotemplate_directive/test_jinja_directive_html.html
+++ b/tests/test_autotemplate_directive/test_jinja_directive_html.html
@@ -10,6 +10,13 @@
         sample_template.in
       </span>
     </span>
+    <a class="reference internal" href="_jinja/sample_template.in.html">
+      <span class="viewcode-link">
+        <span class="pre">
+          [source]
+        </span>
+      </span>
+    </a>
     <a class="headerlink" href="#template-sample_template.in" title="Link to this definition">
       ¶
     </a>

--- a/tests/test_autotemplate_directive/test_several_comments.html
+++ b/tests/test_autotemplate_directive/test_several_comments.html
@@ -10,6 +10,13 @@
         multiple_comments_template.in
       </span>
     </span>
+    <a class="reference internal" href="_jinja/multiple_comments_template.in.html">
+      <span class="viewcode-link">
+        <span class="pre">
+          [source]
+        </span>
+      </span>
+    </a>
     <a class="headerlink" href="#template-multiple_comments_template.in" title="Link to this definition">
       ¶
     </a>

--- a/tests/test_autotemplate_directive/test_templatedir.html
+++ b/tests/test_autotemplate_directive/test_templatedir.html
@@ -10,6 +10,13 @@
         templatedir/template1.in
       </span>
     </span>
+    <a class="reference internal" href="_jinja/templatedir/template1.in.html">
+      <span class="viewcode-link">
+        <span class="pre">
+          [source]
+        </span>
+      </span>
+    </a>
     <a class="headerlink" href="#template-templatedir-template1.in" title="Link to this definition">
       ¶
     </a>
@@ -57,6 +64,13 @@
         templatedir/template2.in
       </span>
     </span>
+    <a class="reference internal" href="_jinja/templatedir/template2.in.html">
+      <span class="viewcode-link">
+        <span class="pre">
+          [source]
+        </span>
+      </span>
+    </a>
     <a class="headerlink" href="#template-templatedir-template2.in" title="Link to this definition">
       ¶
     </a>

--- a/tests/test_viewsource.py
+++ b/tests/test_viewsource.py
@@ -1,0 +1,63 @@
+import pytest
+
+from jinja_autodoc.viewsource import template_source_path
+
+
+@pytest.mark.sphinx("html", testroot="viewsource")
+def test_source_page(app, status, warning):
+    """Documented templates get a link to a page displaying their source."""
+    app.builder.build_all()
+    index = (app.outdir / "index.html").read_text(encoding="utf8")
+    assert "_jinja/greeting.html.html" in index
+    assert index.count("[source]") == 1
+
+    page = (app.outdir / "_jinja" / "greeting.html.html").read_text(encoding="utf8")
+    assert "Hello" in page
+    assert "[docs]" in page
+
+
+@pytest.mark.sphinx("html", testroot="viewsource")
+def test_no_page_outside_the_template_root(app, status, warning):
+    """Only templates living in the template root get a source page."""
+    app.builder.build_all()
+    pages = sorted(path.name for path in (app.outdir / "_jinja").iterdir())
+    assert pages == ["greeting.html.html"]
+
+
+@pytest.mark.sphinx("text", testroot="viewsource")
+def test_unsupported_builder(app, status, warning):
+    """Builders that cannot link to the source pages get no link at all."""
+    app.builder.build_all()
+    assert "[source]" not in (app.outdir / "index.txt").read_text(encoding="utf8")
+
+
+def test_template_source_path(tmp_path):
+    """Signatures escaping the template root are rejected."""
+    root = tmp_path / "templates"
+    root.mkdir()
+    template = root / "greeting.html"
+    template.write_text("{# doc #}\n")
+    outside = tmp_path / "conf.py"
+    outside.write_text("{# doc #}\n")
+
+    assert template_source_path(str(root), "greeting.html") == str(template)
+    assert template_source_path(str(root), "unknown.html") is None
+    assert template_source_path(str(root), "") is None
+    assert template_source_path(str(root), "../conf.py") is None
+    assert template_source_path(str(root), str(outside)) is None
+    assert template_source_path("", "greeting.html") is None
+
+
+@pytest.mark.sphinx("singlehtml", testroot="viewsource")
+def test_unsupported_html_builder(app, status, warning):
+    """HTML builders that cannot reach the source pages do not get them."""
+    app.builder.build_all()
+    assert "[source]" not in (app.outdir / "index.html").read_text(encoding="utf8")
+    assert not (app.outdir / "_jinja").exists()
+
+
+@pytest.mark.sphinx("epub", testroot="viewsource")
+def test_epub_builder(app, status, warning):
+    """Source pages are not generated for epub, which cannot list them."""
+    app.builder.build_all()
+    assert not (app.outdir / "_jinja").exists()


### PR DESCRIPTION
Documented templates now get a link to a page displaying their highlighted source, the way sphinx.ext.viewcode does for python modules. Only templates living inside jinja_template_path get such a page, so that a signature cannot expose an arbitrary file of the machine building the documentation.

fixes #1